### PR TITLE
AWS Lambda Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ package-lock.json
 
 # Mac OS X
 .DS_Store
+
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ package-lock.json
 
 *.zip
 /aws-lambda/go/helloworld
-/aws-lambda/go/handled_exception
+/aws-lambda/go/handled_exception/main
 /aws-lambda/go/unhandled_exception/main

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ package-lock.json
 .DS_Store
 
 *.zip
+/aws-lambda/go/helloworld
+/aws-lambda/go/handled_exception
+/aws-lambda/go/unhandled_exception/main

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -1,4 +1,4 @@
-# Steps to test Sentry SDK integration with Node Lambda function:
+# Steps to test Sentry SDK integration with Go Lambda function:
 
 [Demo Video](https://www.loom.com/share/e3625614df2f44f3bb96286ad7212f99)
 
@@ -16,7 +16,7 @@ GOOS=linux go build main.go
 zip function.zip main
 
 // Include source code in zip to view source code in stacktrace.
-// Or, setup your Sentry<>Github integration instead.
+// Or, setup a Sentry<>Github integration docs.sentry.io/product/integrations/github/
 zip -r function.zip main main.go
 ```
 

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -1,0 +1,21 @@
+# Steps to test Sentry SDK integration with Node Lambda function:
+TODO
+
+## Create a development package
+1. Clone the git repo on your development machine.
+
+2. Build your executable by running `GOOS=linux go build main.go`
+
+3. Make it into a zip by `zip function.zip main`. Make sure your Runtime Setting's handler name matches the name of your executable (i.e. main).
+
+
+## Upload Zip file to Lambda function on AWS.
+1. Create a Go lambda function in AWS Lambda
+2. Function code > Actions > Upload zip
+3. Click 'Test', the request payload is accessible as the second arg to the handler function:
+```
+// MyEvent is a struct type representing the request payload
+func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
+    ...
+}
+```

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -8,7 +8,7 @@
 2. Build your executable by running
 
 ```
-GOOS=linux go build main.go
+GOOS=linux GOARCH=amd64 go build main.go
 ```
 
 3. Create a zip

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -1,5 +1,7 @@
 # Steps to test Sentry SDK integration with Node Lambda function:
 
+[Demo Video](https://www.loom.com/share/e3625614df2f44f3bb96286ad7212f99)
+
 ## Create a development package
 1. Clone the git repo on your development machine.
 

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -14,6 +14,8 @@ GOOS=linux go build -o bin/upload-image functions/upload-image/main.go && zip -r
 how about:  
 ```
 GOOS=linux go build main.go && zip function.zip main
+GOOS=linux go build main.go && zip -r function.zip main main.go
+
 ```
 3. Make it into a zip by `zip function.zip main`. Make sure your Runtime Setting's handler name matches the name of your executable (i.e. main).
 

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -6,6 +6,15 @@ TODO
 
 2. Build your executable by running `GOOS=linux go build main.go`
 
+TODO
+```
+// https://docs.sentry.io/platforms/go/serverless/
+GOOS=linux go build -o bin/upload-image functions/upload-image/main.go && zip -r handler.zip bin/upload-image functions/upload-image/ helper/ util/
+```
+how about:  
+```
+GOOS=linux go build main.go && zip function.zip main
+```
 3. Make it into a zip by `zip function.zip main`. Make sure your Runtime Setting's handler name matches the name of your executable (i.e. main).
 
 
@@ -14,8 +23,16 @@ TODO
 2. Function code > Actions > Upload zip
 3. Click 'Test', the request payload is accessible as the second arg to the handler function:
 ```
-// MyEvent is a struct type representing the request payload
-func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
-    ...
+func HandleRequest(ctx context.Context, payload Payload) (string, error) {
+	return fmt.Sprintf("Hello: %s!", payload.Name), nil
 }
 ```
+
+
+## Additional Documentation
+https://github.com/getsentry/examples/tree/master/aws-lambda
+https://github.com/getsentry/examples/tree/master/gcp-cloud-functions
+
+https://docs.sentry.io/platforms/go/serverless/
+
+https://github.com/getsentry/sentry-go

--- a/aws-lambda/go/README.md
+++ b/aws-lambda/go/README.md
@@ -1,35 +1,43 @@
 # Steps to test Sentry SDK integration with Node Lambda function:
-TODO
 
 ## Create a development package
 1. Clone the git repo on your development machine.
 
-2. Build your executable by running `GOOS=linux go build main.go`
-
-TODO
-```
-// https://docs.sentry.io/platforms/go/serverless/
-GOOS=linux go build -o bin/upload-image functions/upload-image/main.go && zip -r handler.zip bin/upload-image functions/upload-image/ helper/ util/
-```
-how about:  
-```
-GOOS=linux go build main.go && zip function.zip main
-GOOS=linux go build main.go && zip -r function.zip main main.go
+2. Build your executable by running
 
 ```
-3. Make it into a zip by `zip function.zip main`. Make sure your Runtime Setting's handler name matches the name of your executable (i.e. main).
+GOOS=linux go build main.go
+```
 
+3. Create a zip
+```
+zip function.zip main
+
+// Include source code in zip to view source code in stacktrace.
+// Or, setup your Sentry<>Github integration instead.
+zip -r function.zip main main.go
+```
 
 ## Upload Zip file to Lambda function on AWS.
-1. Create a Go lambda function in AWS Lambda
-2. Function code > Actions > Upload zip
-3. Click 'Test', the request payload is accessible as the second arg to the handler function:
-```
-func HandleRequest(ctx context.Context, payload Payload) (string, error) {
-	return fmt.Sprintf("Hello: %s!", payload.Name), nil
-}
-```
 
+1. Create a Go lambda function in AWS Lambda.
+2. Function code > Actions > Upload zip
+3. Click 'Test', the request payload is accessible as the second argument in the handler function.
+
+## Usage
+Common to any/all examples below, you'd need to __Configure test events__ for each Lambda function. 
+ * Goto the Lambda function on your AWS Management console
+ * Click *Test* on the far right.
+ * Enter Event name such as MyTestEvent.
+ * Leave the json as is or make it an empty json, your choice :-)
+ * Click Create.
+ * Follow specifics of the examples below.
+ * __Click Test to send your example event to Sentry !!__
+
+## Troubleshooting
+Make sure your lambda Runtime Setting's handler name matches the name of your executable (i.e. main) or your function won't be found when you run the Test.
+
+Setting GOOS to linux ensures that the compiled executable is compatible with the Go runtime, even if you compile it in a non-Linux environment.
 
 ## Additional Documentation
 https://github.com/getsentry/examples/tree/master/aws-lambda
@@ -38,3 +46,5 @@ https://github.com/getsentry/examples/tree/master/gcp-cloud-functions
 https://docs.sentry.io/platforms/go/serverless/
 
 https://github.com/getsentry/sentry-go
+
+https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html

--- a/aws-lambda/go/handled_exception/main.go
+++ b/aws-lambda/go/handled_exception/main.go
@@ -26,7 +26,7 @@ func HandleRequest(ctx context.Context, payload Payload) (string, error) {
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   "<your DSN>",
+		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
 		Debug: true,
 	})
 	if err != nil {

--- a/aws-lambda/go/handled_exception/main.go
+++ b/aws-lambda/go/handled_exception/main.go
@@ -26,7 +26,7 @@ func HandleRequest(ctx context.Context, payload Payload) (string, error) {
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Dsn:   "<your DSN>",
 		Debug: true,
 	})
 	if err != nil {

--- a/aws-lambda/go/handled_exception/main.go
+++ b/aws-lambda/go/handled_exception/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/getsentry/sentry-go"
+)
+
+type Payload struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(ctx context.Context, payload Payload) (string, error) {
+	defer sentry.Flush(2 * time.Second)
+	fmt.Println("handled_exception")
+
+	sentry.CaptureException(errors.New("handled, capture exception"))
+
+	return fmt.Sprintf("Program: %s!", payload.Name), nil
+}
+
+func main() {
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Debug: true,
+	})
+	if err != nil {
+		log.Fatalf("sentry.Init: %s", err)
+	}
+	lambda.Start(HandleRequest)
+}

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -15,7 +15,8 @@ type Payload struct {
 }
 
 func HandleRequest(ctx context.Context, payload Payload) (string, error) {
-	fmt.Println("this appears in the lambda log.....")
+	defer sentry.Flush(2 * time.Second)
+	fmt.Println("testing...")
 	sentry.CaptureMessage("serverless function (lambda) AWS")
 	return fmt.Sprintf("Program: %s!", payload.Name), nil
 }
@@ -28,6 +29,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}
-	defer sentry.Flush(2 * time.Second)
 	lambda.Start(HandleRequest)
 }

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -16,14 +16,15 @@ type Payload struct {
 
 func HandleRequest(ctx context.Context, payload Payload) (string, error) {
 	defer sentry.Flush(2 * time.Second)
-	fmt.Println("testing...")
+
 	sentry.CaptureMessage("serverless function (lambda) AWS")
+
 	return fmt.Sprintf("Program: %s!", payload.Name), nil
 }
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Dsn:   "<your DSN>",
 		Debug: true,
 	})
 	if err != nil {

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -28,9 +28,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}
-	lambda.Start(HandleRequest)
-	// TODO try putting it after...
-
-	// EVAL prob put at end of 'main'
 	defer sentry.Flush(2 * time.Second)
+	lambda.Start(HandleRequest)
 }

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -15,7 +15,7 @@ type Payload struct {
 }
 
 func HandleRequest(ctx context.Context, payload Payload) (string, error) {
-	fmt.Println("testing.....")
+	fmt.Println("this appears in the lambda log.....")
 	sentry.CaptureMessage("serverless function (lambda) AWS")
 	return fmt.Sprintf("Program: %s!", payload.Name), nil
 }
@@ -24,8 +24,6 @@ func main() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
 		Debug: true,
-		// Release: "my-project-name@1.0.0",
-		// Environment: "production"
 	})
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type MyEvent struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
+	return fmt.Sprintf("Hello: %s!", name.Name), nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/aws-lambda/go/helloworld/main.go
+++ b/aws-lambda/go/helloworld/main.go
@@ -3,18 +3,36 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/getsentry/sentry-go"
 )
 
-type MyEvent struct {
+type Payload struct {
 	Name string `json:"name"`
 }
 
-func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
-	return fmt.Sprintf("Hello: %s!", name.Name), nil
+func HandleRequest(ctx context.Context, payload Payload) (string, error) {
+	fmt.Println("testing.....")
+	sentry.CaptureMessage("serverless function (lambda) AWS")
+	return fmt.Sprintf("Program: %s!", payload.Name), nil
 }
 
 func main() {
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Debug: true,
+		// Release: "my-project-name@1.0.0",
+		// Environment: "production"
+	})
+	if err != nil {
+		log.Fatalf("sentry.Init: %s", err)
+	}
 	lambda.Start(HandleRequest)
+	// TODO try putting it after...
+
+	// EVAL prob put at end of 'main'
+	defer sentry.Flush(2 * time.Second)
 }

--- a/aws-lambda/go/unhandled_exception/main.go
+++ b/aws-lambda/go/unhandled_exception/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/getsentry/sentry-go"
+)
+
+type Payload struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(ctx context.Context, payload Payload) (string, error) {
+	defer sentry.Flush(2 * time.Second)
+
+	myList := make([]int, 2)
+
+	fmt.Println(myList[4])
+
+	return fmt.Sprintf("Program: %s!", payload.Name), nil
+}
+
+func main() {
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Debug: true,
+	})
+	if err != nil {
+		log.Fatalf("sentry.Init: %s", err)
+	}
+	lambda.Start(HandleRequest)
+}

--- a/aws-lambda/go/unhandled_exception/main.go
+++ b/aws-lambda/go/unhandled_exception/main.go
@@ -16,9 +16,9 @@ type Payload struct {
 
 func HandleRequest(ctx context.Context, payload Payload) (string, error) {
 	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
 
 	myList := make([]int, 2)
-
 	fmt.Println(myList[4])
 
 	return fmt.Sprintf("Program: %s!", payload.Name), nil
@@ -26,7 +26,7 @@ func HandleRequest(ctx context.Context, payload Payload) (string, error) {
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   "https://879a3ddfdd5241b0b4f6fcf9011896ad@o87286.ingest.sentry.io/5426957",
+		Dsn:   "<your DSN>",
 		Debug: true,
 	})
 	if err != nil {


### PR DESCRIPTION
### Type of Change
- [x] New Feature

### Description
To capture errors in serverless functions. 3 go lambdas developed, deployed and tested.

README.md added in aws-lambda/go/

### Versions
go1.15. 
sentry go sdk 0.7.0. 
aws-lambda-go 1.22.0. 

### Testing
`hello_world` Message
https://sentry.io/organizations/testorg-az/issues/2167126836/?project=5426957&query=is%3Aunresolved

`handled_exception` is level:error
https://sentry.io/organizations/testorg-az/issues/2168272248/?project=5426957&query=is%3Aunresolved

`unhandled_exception` is level:fatal
https://sentry.io/organizations/testorg-az/issues/2169597284/?project=5426957

### Note
Golang does not have the same distinctions of Handled vs Unhandled or even an 'exceptions class' in general. I've preserved handled vs. unhandled for now, only to keep this aligned with how demo's + repo's are structured. Eventually will probably get rid of it for Go.